### PR TITLE
[#7] 레이아웃 컴포넌트 구현 및 라우터 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,38 @@
-import React from 'react';
-import Header from './components/common/Header';
+import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+import Layout from './components/layout/Layout';
+
+const routeList = [
+  {
+    path: '/',
+    element: <h1>Home Component</h1>
+  },
+  {
+    path: '/login',
+    element: <h1>Login Component</h1>
+  },
+  {
+    path: '/join',
+    element: <h1>Join Component</h1>
+  },
+  {
+    path: '/quiz',
+    element: <h1>Quiz Component</h1>
+  },
+]
+
+const rotuer = createBrowserRouter(
+  routeList.map((item) => {
+    return {
+      ...item,
+      element: <Layout>{item.element}</Layout>
+    }
+  })
+);
 
 const App = () => {
   return (
-    <>
-      <Header />
-    </>
+    <RouterProvider router={rotuer} />
   )
-}
+};
 
 export default App;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,15 +1,22 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 const Header = () => {
   return (
     <HeaderWrapper>
       <Content>
         <div className='logo'>
-          <h1>Quiz</h1>
+          <Link to='/'>
+            <h1>Quiz</h1>
+          </Link>
         </div>
         <div className="auth">
-          <button>JOIN</button>
-          <button>LOGIN</button>
+          <Link to='/join'>
+            <button>JOIN</button>
+          </Link>
+          <Link to='/login'>
+            <button>LOGIN</button>
+          </Link>
         </div>
       </Content>
     </HeaderWrapper>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -20,7 +20,7 @@ const LayoutWrapper = styled.main`
   margin: 0 auto;
   padding: 0;
   width: 100%;
-  height: calc(100vh - 64px);
+  height: 100%;
   max-width: 1200px;
 `;
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+import Header from '../common/Header';
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+const Layout = ({ children }: LayoutProps) => {
+  return (
+    <>
+      <Header />
+      <LayoutWrapper>
+        {children}
+      </LayoutWrapper>
+    </>
+  )
+};
+
+const LayoutWrapper = styled.main`
+  margin: 0 auto;
+  padding: 0;
+  width: 100%;
+  height: calc(100vh - 64px);
+  max-width: 1200px;
+  border: 1px solid red;
+`;
+
+export default Layout;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -22,7 +22,6 @@ const LayoutWrapper = styled.main`
   width: 100%;
   height: calc(100vh - 64px);
   max-width: 1200px;
-  border: 1px solid red;
 `;
 
 export default Layout;


### PR DESCRIPTION
## 📝 작업 내용

- 재사용 가능한 레이아웃 컴포넌트를 개발하였습니다. (헤더 포함 O)
- 라우터 기능을 App 컴포넌트에 개발하였습니다.

## ⭐️ 중점적으로 봐야 할 부분

- 화면 가로 크기를 1440px로 잡고 시작했기 때문에, 화면 안에 들어갈 내용은 1200px부터 잡았습니다. (미디어 쿼리 적용 X)
(높이는 혹시 몰라서 `calc(100%-64px)` 대신 `100%` 사용했습니다! 추후 변경 필요 시 아무나 변경해주셔도 됩니당)
- padding 적용 안되어있는 상태
- 라우트 경로는 임시로 해놓아서 나중에 추가 및 수정 해주시면 됩니다!

![#7-레이아웃](https://github.com/DevSimpleQuiz/Frontend/assets/58524208/1759583f-a41b-4a24-a65d-66d1ab6e8eb4)
