### PR TITLE
[#15] 로그인 및 회원가입 api 연동, 쿠키로 token 받아오기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import Home from "./pages/Home";
 import Error from "./components/common/Error";
 import Login from './pages/Login';
 import Join from './pages/Join';
-import { AuthProvider } from './context/AuthContext';
 
 const routeList = [
   {
@@ -39,9 +38,7 @@ const rotuer = createBrowserRouter(
 
 const App = () => {
   return (
-    <AuthProvider>
-      <RouterProvider router={rotuer} />
-    </AuthProvider>
+    <RouterProvider router={rotuer} />
   )
 };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import Layout from "./components/layout/Layout";
-import Join from './pages/Join';
 import Quiz from "./pages/Quiz";
 import Ranking from "./pages/Ranking";
 import Home from "./pages/Home";

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,0 +1,21 @@
+import { JoinProps } from "../pages/Join";
+import { LoginProps } from "../pages/Login";
+import { httpClient } from "./http";
+
+// 회원가입
+export const join = async (data: JoinProps) => {
+  const response = await httpClient.post("/join", data);
+
+  return response.data;
+};
+
+// 로그인
+interface LoginResponse {
+  token: string;
+}
+
+export const login = async (data: LoginProps) => {
+  const response = await httpClient.post<LoginResponse>("/login", data);
+
+  return response.data;
+};

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,0 +1,37 @@
+import axios, { AxiosRequestConfig } from "axios";
+import { getToken, removeToken } from "../store/authStore";
+
+const BASE_URL = "http://localhost:4242";
+const DEFAULT_TIMEOUT = 30000;
+
+export const createClient = (config?: AxiosRequestConfig) => {
+  const axiosInstance = axios.create({
+    baseURL: BASE_URL,
+    timeout: DEFAULT_TIMEOUT,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: getToken() ? getToken() : '',
+    },
+    withCredentials: true,
+    ...config,
+  });
+
+  axiosInstance.interceptors.request.use(
+    (response) => {
+      return response;
+    },
+    (error) => {
+      // 토큰이 만료되었을 때
+      if(error.response.status === 401) {
+        removeToken();
+        window.location.href = '/login';
+        return;
+      }
+      // 로그인 만료 처리
+      return Promise.reject(error);
+    }
+  );
+  return axiosInstance;
+};
+
+export const httpClient = createClient();

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -4,10 +4,7 @@ import Button from '../Button';
 import { useAuthStore } from '../../store/authStore';
 
 const Header = () => {
-  const { isLoggedIn, storeLogout } = useAuthStore((state) => ({
-    isLoggedIn: state.isLoggedIn,
-    storeLogout: state.storeLogout,
-  }));
+  const { isLoggedIn, storeLogout } = useAuthStore();
 
   return (
     <HeaderWrapper>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import Button from '../Button';
-import { useAuth } from '../../context/AuthContext';
+import { useAuthStore } from '../../store/authStore';
 
 const Header = () => {
-  const { isLoggedIn, logout } = useAuth();
+  const { isLoggedIn, storeLogout } = useAuthStore((state) => ({
+    isLoggedIn: state.isLoggedIn,
+    storeLogout: state.storeLogout,
+  }));
 
   return (
     <HeaderWrapper>
@@ -21,7 +23,7 @@ const Header = () => {
               <Link to='/mypage'>
                 <Button size='short' schema='normal'>MY PAGE</Button>
               </Link>
-              <Button size='short' schema='normal' onClick={logout}>LOGOUT</Button>
+              <Button size='short' schema='normal' onClick={storeLogout}>LOGOUT</Button>
             </>
           ) : (
             <>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,31 @@
+import { useNavigate } from "react-router-dom";
+import { useAuthStore } from "../store/authStore";
+import { LoginProps } from "../pages/Login";
+import { join, login } from "../api/auth.api";
+import { JoinProps } from "../pages/Join";
+
+export const useAuth = () => {
+  const navigation = useNavigate();
+  const { storeLogin } = useAuthStore();
+
+  const userLogin = (data: LoginProps) => {
+    login(data).then((res) => {
+      storeLogin(res.token);
+      window.alert("로그인이 완료되었습니다.");
+      navigation("/");
+    }, (err) => {
+      window.alert("로그인에 실패하였습니다.");
+      window.location.reload();
+    })
+  };
+
+  const userJoin = (data: JoinProps) => {
+    join(data).then((res) => {
+      console.log(data);
+      window.alert("회원가입이 완료되었습니다.");
+      navigation("/login");
+    })
+  };
+
+  return { userLogin, userJoin };
+};

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -10,7 +10,7 @@ export const useAuth = () => {
 
   const userLogin = (data: LoginProps) => {
     login(data).then((res) => {
-      storeLogin(res.token);;
+      storeLogin(res.token);
       window.alert("로그인이 완료되었습니다.");
       navigation("/");
     }, (err) => {
@@ -21,7 +21,6 @@ export const useAuth = () => {
 
   const userJoin = (data: JoinProps) => {
     join(data).then((res) => {
-      console.log(data);
       window.alert("회원가입이 완료되었습니다.");
       navigation("/login");
     })

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -10,7 +10,7 @@ export const useAuth = () => {
 
   const userLogin = (data: LoginProps) => {
     login(data).then((res) => {
-      storeLogin(res.token);
+      storeLogin(res.token);;
       window.alert("로그인이 완료되었습니다.");
       navigation("/");
     }, (err) => {

--- a/src/pages/Join.tsx
+++ b/src/pages/Join.tsx
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
 import Button from '../components/Button';
 import { FormWrapper } from '../components/common/FormWrapper';
-import { SubmitHandler, useForm } from 'react-hook-form';
-import { Link, useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { Link } from 'react-router-dom';
 import { useRef } from 'react';
 import { FiInfo } from "react-icons/fi";
+import { useAuth } from '../hooks/useAuth';
 
 export interface JoinProps {
   id: string;
@@ -20,15 +21,13 @@ const Join = () => {
     formState: { errors, isSubmitted }
   } = useForm<JoinProps>();
 
-  const navigate = useNavigate();
+  const { userJoin } = useAuth();
 
   const passwordRef = useRef<string | null>(null);
   passwordRef.current = watch("password");
 
-  const onSubmit: SubmitHandler<JoinProps> = (data) => {
-    console.log(data);
-    window.alert('회원가입이 완료되었습니다.');
-    navigate('/login');
+  const onSubmit = (data: JoinProps) => {
+    userJoin(data);
   };
 
   return (
@@ -52,6 +51,7 @@ const Join = () => {
               type='button'
               size='short' 
               schema='normal'
+              onClick={() => onSubmit}
             >중복 확인</Button>
           </div>
           <p className={`join-info ${isSubmitted && (errors.id ? 'invalid' : 'valid')}`}>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 import { FormWrapper } from '../components/common/FormWrapper';
 import Button from '../components/Button';
 import { useForm } from 'react-hook-form';
-import { Link, useNavigate } from 'react-router-dom';
-import { useAuth } from '../context/AuthContext';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
 
 export interface LoginProps {
   id: string;
@@ -17,15 +17,10 @@ const Login = () => {
     formState: { errors }
   } = useForm<LoginProps>();
 
-  const navigate = useNavigate();
-  const { login } = useAuth();
+  const { userLogin } = useAuth();
 
   const onSubmit = (data: LoginProps) => {
-    console.log(data);
-    window.alert('로그인이 완료되었습니다.');
-    const userId = data.id;
-    login(userId);
-    navigate('/');
+    userLogin(data);
   };
 
   return (

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -13,7 +13,6 @@ export const getToken = () => {
 
 const setToken = (token: string) => {
   localStorage.setItem("token", token);
-  console.log(token);
 };
 
 export const removeToken = () => {
@@ -29,5 +28,5 @@ export const useAuthStore = create<StoreState>((set) => ({
   storeLogout: () => {
     set({ isLoggedIn: false });
     removeToken();
-  },
+  }
 }));

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+
+interface StoreState {
+  isLoggedIn: boolean;
+  storeLogin: (token: string) => void;
+  storeLogout: () => void;
+}
+
+export const getToken = () => {
+  const token = localStorage.getItem("token");
+  return token;
+};
+
+const setToken = (token: string) => {
+  localStorage.setItem("token", token);
+  console.log(token);
+};
+
+export const removeToken = () => {
+  localStorage.removeItem("token");
+};
+
+export const useAuthStore = create<StoreState>((set) => ({
+  isLoggedIn: getToken() ? true : false,
+  storeLogin: (token) => {
+    set({ isLoggedIn: true });
+    setToken(token);
+  },
+  storeLogout: () => {
+    set({ isLoggedIn: false });
+    removeToken();
+  },
+}));


### PR DESCRIPTION
## 📝 작업 내용

- 회원가입 진행 후 해당 정보로만 로그인 가능하게 구현하였습니다.

## ⭐️ 중점적으로 봐야 할 부분

- 예를 들어 id는 `quiz1`, pw는 `Quiz1234?` 로 **회원가입 되어있을 때**
![image](https://github.com/DevSimpleQuiz/Frontend/assets/58524208/2edaa864-1502-4d46-b51e-86f39e117d8d)
![image](https://github.com/DevSimpleQuiz/Frontend/assets/58524208/5153da58-0007-4751-9681-f34f591edf7c)

✅ 로그인에 성공하면 "로그인이 완료되었습니다" 라는 문구가 뜨고, 확인 버튼을 누르게 되면 홈으로 넘어갑니다.
✅ 헤더가 로그인 상태로 바뀐 것을 확인 할 수 있으며 응답 헤더의 쿠키값으로 토큰이 들어와있는 것을 알 수 있습니다.
✅ 한 번 저장된 쿠키(토큰)는 지정한 시간이 지나기 전까지는 계속 저장되어 있습니다.

<br>

- **로그인에 실패했을 때**
![image](https://github.com/DevSimpleQuiz/Frontend/assets/58524208/ae804d8a-619f-4eec-9e20-a6d22744aec0)

✅ 쿠키는 저장되어 있으나 로그인 정보가 맞지 않다면 401 에러를 확인할 수 있습니다.

<br>

- **로그인 후 새로고침 했을 때**
![로그인-새로고침](https://github.com/DevSimpleQuiz/Frontend/assets/58524208/e707de75-392d-432a-ac52-b8901076827d)

✅ 로그인 상태에서 계속 새로고침을 해도 로그인 상태로 유지됩니다.

## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
