### PR TITLE
[#21] 랭킹 조회 페이지

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,7 +1,6 @@
 import { JoinProps } from "../pages/Join";
 import { LoginProps, LoginToken } from "../pages/Login";
 import { httpClient } from "./http";
-import axios from 'axios';
 
 // 회원가입
 export const join = async (data: JoinProps) => {

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -27,10 +27,13 @@ export const createClient = (config?: AxiosRequestConfig) => {
     },
     (error) => {
       // 토큰이 만료되었을 때
-      if (error.response && error.response.status === 401) {
+      if (error.response && 
+        error.response.status === 401 || error.response.status === 403
+      ) {
+        window.alert("일정시간이 지나 로그아웃 되었습니다.");
         window.location.href = "/users/login";
         return;
-      }
+      } 
       // 로그인 만료 처리
       return Promise.reject(error);
     }

--- a/src/api/rank.api.ts
+++ b/src/api/rank.api.ts
@@ -1,0 +1,20 @@
+import { httpClient } from "./http";
+import { NearRank, Rank, TopRank } from "../models/rank.model";
+
+export const fetchRank = async () => {
+  const response = await httpClient.get<Rank>("/rank");
+
+  return response.data;
+};
+
+export const fetchTopRank = async () => {
+  const response = await httpClient.get<TopRank>("/rank");
+
+  return response.data;
+};
+
+export const fetchNearRank = async () => {
+  const response = await httpClient.get<NearRank>("/rank");
+
+  return response.data;
+};

--- a/src/components/common/rank/NearRank.tsx
+++ b/src/components/common/rank/NearRank.tsx
@@ -1,15 +1,10 @@
 import styled from 'styled-components';
 import { Rank } from '../../../models/rank.model';
+import { useRank } from '../../../hooks/useRank';
 
-interface NearRankProps {
-  myRank: Rank;
-  nearRank: Rank[];
-}
-
-const NearRank = ({ myRank, nearRank }: NearRankProps) => {
-  const startIndex = nearRank.findIndex(data => data.id === myRank.id);
-  const nearRankData = nearRank.slice(startIndex - 1, startIndex + 2);
-
+const NearRank = ({ id }: Rank) => {
+  const { nearRank } = useRank();
+  
   return (
     <NearRankWrapper>
       <table>
@@ -21,11 +16,14 @@ const NearRank = ({ myRank, nearRank }: NearRankProps) => {
           </tr>
         </thead>
         <tbody>
-          {nearRankData.map((data, idx) => (
-            <tr key={idx} className={data.id === myRank.id ? "highlight" : ''}>
+          {nearRank?.nearRankers.map((data, idx) => (
+            <tr
+              key={idx} 
+              className={data.id === id ? "highlight" : ''}
+            >
               <td>{data.rank}</td>
               <td>{data.id}</td>
-              <td>{data.score}점</td>
+              <td>{data.totalScore}점</td>
             </tr>
           ))}
         </tbody>

--- a/src/components/common/rank/RankCard.tsx
+++ b/src/components/common/rank/RankCard.tsx
@@ -2,20 +2,20 @@ import styled from 'styled-components';
 import { FaUser } from "react-icons/fa";
 import { Rank } from '../../../models/rank.model';
 
-const RankCard = ({ id, rank, score }: Rank) => {
+const RankCard = ({ id, rank, totalQuizScore }: Rank) => {
   return (
     <RankCardWrapper rank={rank}>
       <h1 className="rank">{rank}</h1>
       <div className="user">
         <div className="profile"><FaUser /></div>
         <div className="id">{id}</div>
-        <div className="score">{score}점</div>
+        <div className="score">{totalQuizScore}점</div>
       </div>
     </RankCardWrapper>
   )
 };
 
-const RankCardWrapper = styled.div<{ rank: number }>`
+const RankCardWrapper = styled.div<{ rank: number | undefined }>`
   padding: 16px 28px;
   padding-bottom: 40px;
   height: 100%;

--- a/src/components/common/rank/UnAuthorizedRank.tsx
+++ b/src/components/common/rank/UnAuthorizedRank.tsx
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+import { Content, HighRank, MyRank, RankWrapper } from '../../../pages/Rank'
+import { Link } from 'react-router-dom';
+
+const UnAuthorizedRank = () => {
+
+  return (
+    <RankWrapper>
+    <h1 className="title">나의 랭킹</h1>
+    <Content>
+      <MyRank>
+        <div className="rank-box">
+          <div className="rank-zone">
+            <h1>RANK</h1>
+            <span>-</span>
+          </div>
+          <div className="line"></div>
+          <div className="go-page">
+            <Link to='/'>메인 화면으로 가기</Link>
+          </div>
+        </div>
+        <div className="score-box">
+          <h2>로그인 후 이용 가능합니다.</h2>
+        </div>
+      </MyRank>
+      <UnAuthorizedContent>
+        <h2>로그인 후 이용 가능합니다.</h2>
+        <Link to='/users/login'>
+            <h3>로그인 하러 가기</h3>
+          </Link>
+      </UnAuthorizedContent>
+    </Content>
+  </RankWrapper>
+  )
+}
+
+export default UnAuthorizedRank;
+
+const UnAuthorizedContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: calc(100vh - 448px);
+  border: 1px solid ${({ theme }) => theme.color.grey3};
+  border-radius: 8px;
+
+  h2 {
+    font-size: ${({ theme }) => theme.heading.title3};
+    font-weight: 600;
+  }
+
+  h3 {
+    font-size: ${({ theme }) => theme.heading.title4};
+    font-weight: 400;
+  }
+
+  a {
+    color: ${({ theme }) => theme.color.primary};
+    text-decoration: underline;
+  }
+`;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -28,7 +28,6 @@ export const useAuth = () => {
     } catch (err) {
       window.alert("존재하지 않는 유저입니다.");
       window.location.reload();
-      throw err;
     }
   };
   

--- a/src/hooks/useRank.ts
+++ b/src/hooks/useRank.ts
@@ -1,24 +1,3 @@
-// import { useEffect, useState } from "react";
-// import { Rank } from "../models/rank.model";
-// import { fetchRank } from "../api/rank.api";
-
-// export const useRank = () => {
-//   const [userRank, setUserRank] = useState<Rank>();
-
-//   useEffect(() => {
-//     fetchRank().then((data) => {
-//       setUserRank(data);
-//     })
-//   }, []);
-  
-//   console.log(userRank);
-
-//   return { userRank };
-// };
-
-
-// useRank.ts
-
 import { useEffect, useState } from "react";
 import { NearRank, Rank, TopRank } from "../models/rank.model";
 import { fetchNearRank, fetchRank, fetchTopRank } from "../api/rank.api";

--- a/src/hooks/useRank.ts
+++ b/src/hooks/useRank.ts
@@ -1,0 +1,49 @@
+// import { useEffect, useState } from "react";
+// import { Rank } from "../models/rank.model";
+// import { fetchRank } from "../api/rank.api";
+
+// export const useRank = () => {
+//   const [userRank, setUserRank] = useState<Rank>();
+
+//   useEffect(() => {
+//     fetchRank().then((data) => {
+//       setUserRank(data);
+//     })
+//   }, []);
+  
+//   console.log(userRank);
+
+//   return { userRank };
+// };
+
+
+// useRank.ts
+
+import { useEffect, useState } from "react";
+import { NearRank, Rank, TopRank } from "../models/rank.model";
+import { fetchNearRank, fetchRank, fetchTopRank } from "../api/rank.api";
+
+export const useRank = () => {
+  const [userRank, setUserRank] = useState<Rank | null>(null);
+  const [topRank, setTopRank] = useState<TopRank | null>(null);
+  const [nearRank, setNearRank] = useState<NearRank | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const userRankData = await fetchRank();
+        const topRankData = await fetchTopRank();
+        const nearRankData = await fetchNearRank();
+        setUserRank(userRankData);
+        setTopRank(topRankData);
+        setNearRank(nearRankData);
+      } catch (err) {
+        console.log(err);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return { userRank, topRank, nearRank };
+};

--- a/src/models/rank.model.ts
+++ b/src/models/rank.model.ts
@@ -1,5 +1,21 @@
 export interface Rank {
   id: string;
+  rank?: number;
+  totalQuizScore?: number;
+  totalQuizCount?: number;
+  totalSolvedQuizCount?: number;
+}
+
+export interface TopRank {
+  topRankers: Ranker[];
+}
+
+export interface NearRank {
+  nearRankers: Ranker[];
+}
+
+export interface Ranker {
+  id: string;
   rank: number;
-  score: number;
+  totalScore: number;
 }

--- a/src/pages/Rank.tsx
+++ b/src/pages/Rank.tsx
@@ -3,12 +3,13 @@ import { Link } from 'react-router-dom';
 import RankCard from '../components/common/rank/RankCard';
 import NearRank from '../components/common/rank/NearRank';
 import { useRank } from '../hooks/useRank';
+import UnAuthorizedRank from '../components/common/rank/UnAuthorizedRank';
 
 const Rank = () => {
   const { userRank, topRank } = useRank();
 
   if (!userRank) {
-    return <div>Loading...</div>;
+    return <UnAuthorizedRank />;
   }
 
   return (
@@ -53,7 +54,7 @@ const Rank = () => {
   );
 };
 
-const RankWrapper = styled.div`
+export const RankWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -66,13 +67,13 @@ const RankWrapper = styled.div`
   }
 `;
 
-const Content = styled.div`
+export const Content = styled.div`
   display: flex;
   flex-direction: column;
   gap: 40px;
 `;
 
-const MyRank = styled.div`
+export const MyRank = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -180,10 +181,18 @@ const MyRank = styled.div`
   }
 `;
 
-const HighRank = styled.div`
+export const HighRank = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 6%;
+
+  div {
+    padding: 16px 28px;
+    width: 100%;
+    height: 100px;
+    border: 1px solid ${({ theme }) => theme.color.grey3};
+    border-radius: 8px;
+  }
 `;
 
 export default Rank;

--- a/src/pages/Rank.tsx
+++ b/src/pages/Rank.tsx
@@ -1,70 +1,16 @@
 import styled from 'styled-components';
-import RankCard from '../components/common/rank/RankCard';
 import { Link } from 'react-router-dom';
+import RankCard from '../components/common/rank/RankCard';
 import NearRank from '../components/common/rank/NearRank';
-
-const allRank = [
-  {
-    id: '김머쓱',
-    rank: 1,
-    score: 1040,
-  },
-  {
-    id: '이머쓱',
-    rank: 2,
-    score: 980,
-  },
-  {
-    id: '박머쓱',
-    rank: 3,
-    score: 760,
-  },
-  {
-    id: '최머쓱',
-    rank: 4,
-    score: 500,
-  },
-  {
-    id: '정머쓱',
-    rank: 5,
-    score: 460,
-  },
-  {
-    id: '하머쓱',
-    rank: 6,
-    score: 400,
-  },
-  {
-    id: '고머쓱',
-    rank: 7,
-    score: 240,
-  },
-  {
-    id: '황머쓱',
-    rank: 8,
-    score: 210,
-  },
-  {
-    id: '양머쓱',
-    rank: 9,
-    score: 110,
-  },
-  {
-    id: '권머쓱',
-    rank: 10,
-    score: 80,
-  },
-];
-
-const myRank = {
-  id: '고머쓱',
-  rank: 7,
-  score: 240,
-  questionNum: 50,
-  correctNum: 24,
-};
+import { useRank } from '../hooks/useRank';
 
 const Rank = () => {
+  const { userRank, topRank } = useRank();
+
+  if (!userRank) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <RankWrapper>
       <h1 className="title">나의 랭킹</h1>
@@ -73,7 +19,7 @@ const Rank = () => {
           <div className="rank-box">
             <div className="rank-zone">
               <h1>RANK</h1>
-              <span>{myRank.rank}</span>
+              <span>{userRank.rank}</span>
             </div>
             <div className="line"></div>
             <div className="go-page">
@@ -83,23 +29,25 @@ const Rank = () => {
             </div>
           </div>
           <div className="score-box">
-            <h2>나의 점수는 <span className="blue">{myRank.score}</span>점</h2>
+            <h2>나의 점수는 <span className="blue">{userRank.totalQuizScore}</span>점</h2>
             <h3>
-              <span className="blue">{myRank.questionNum}</span>문제 중 <span className="blue">{myRank.correctNum}</span>문제를 맞췄네요!
+              <span className="blue">{userRank.totalQuizCount}</span>문제 중 <span className="blue">{userRank.totalSolvedQuizCount}</span>문제를 맞췄네요!
             </h3>
           </div>
         </MyRank>
         <HighRank>
-          {allRank.slice(0, 3).map((data, idx) => (
+        {topRank && topRank.topRankers && 
+          topRank.topRankers.map((data, idx) => (
             <RankCard
               key={idx}
               id={data.id}
               rank={data.rank}
-              score={data.score}
+              totalQuizScore={data.totalScore}
             />
-          ))}
+          ))
+        }
         </HighRank>
-        <NearRank myRank={myRank} nearRank={allRank}/>
+        <NearRank id={userRank.id} />
       </Content>
     </RankWrapper>
   );

--- a/src/pages/Rank.tsx
+++ b/src/pages/Rank.tsx
@@ -175,6 +175,11 @@ export const MyRank = styled.div`
       font-weight: 400;
     }
 
+    a {
+      color: ${({ theme }) => theme.color.primary};
+      text-decoration: underline;
+    }
+
     .blue {
       color: ${({ theme }) => theme.color.blue};
     }
@@ -185,14 +190,6 @@ export const HighRank = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 6%;
-
-  div {
-    padding: 16px 28px;
-    width: 100%;
-    height: 100px;
-    border: 1px solid ${({ theme }) => theme.color.grey3};
-    border-radius: 8px;
-  }
 `;
 
 export default Rank;


### PR DESCRIPTION
## 📝 작업 내용

- 나의 랭킹 정보 조회 (랭크, 총 점수, 풀어본 총 문제, 해결한 문제)
- 상위 사용자(1-3) 랭킹 조회 (상위 사용자의 각 랭크, 아이디, 점수)
- 근처 사용자 랭킹 조회 (근처 사용자의 각 랭크, 아이디, 점수)

## ⭐️ 중점적으로 봐야 할 부분

- userRank.ts > useRank 함수에서 모든 랭크 정보를 가져옴
- 로그인 한 후에 해당 기능 이용 가능
![스크린샷 2024-07-15 오후 5 50 27](https://github.com/user-attachments/assets/01ead6ee-e3ab-4e97-9e92-6f9aeca85128)

- 로그인이 안되어있을 경우 랭킹 확인 불가
![스크린샷 2024-07-15 오후 5 50 48](https://github.com/user-attachments/assets/85712d3a-a805-40b9-965d-5e4e432d5dd0)

- 시연
![나의랭킹-조회](https://github.com/user-attachments/assets/a6d5eeb1-f2eb-4f38-80a2-ef892b5dbb6a)

## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
