### PR TITLE
[#45] 랭킹페이지 분리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Rank from "./pages/Rank";
 import MyPage from "./pages/MyPage";
 import { AuthProvider } from './context/AuthContext';
 import QuizResult from "./pages/QuizResult";
+import InfiniteQuiz from "./pages/InfiniteQuiz";
 
 
 const routeList = [
@@ -30,16 +31,16 @@ const routeList = [
     element: <Quiz />,
   },
   {
+    path: "/infinite-quiz",
+    element: <InfiniteQuiz />,
+  },
+  {
     path: "/reset-password",
     element: <ResetPassword />,
   },
   {
     path: "/error",
     element: <Error />,
-  },
-  {
-    path: '/quiz',
-    element: <Quiz />
   },
   {
 

--- a/src/api/rank.api.ts
+++ b/src/api/rank.api.ts
@@ -2,19 +2,19 @@ import { httpClient } from "./http";
 import { NearRank, Rank, TopRank } from "../models/rank.model";
 
 export const fetchRank = async () => {
-  const response = await httpClient.get<Rank>("/rank");
+  const response = await httpClient.get<Rank>("/rank/my");
 
   return response.data;
 };
 
 export const fetchTopRank = async () => {
-  const response = await httpClient.get<TopRank>("/rank");
+  const response = await httpClient.get<TopRank>("/rank/top");
 
   return response.data;
 };
 
 export const fetchNearRank = async () => {
-  const response = await httpClient.get<NearRank>("/rank");
+  const response = await httpClient.get<NearRank>("/rank/near");
 
   return response.data;
 };

--- a/src/components/common/rank/NearRank.tsx
+++ b/src/components/common/rank/NearRank.tsx
@@ -1,12 +1,13 @@
-import styled from 'styled-components';
-import { Rank } from '../../../models/rank.model';
-import { useRank } from '../../../hooks/useRank';
-import { useAuthStore } from '../../../store/authStore';
+import styled from "styled-components";
+import { Rank } from "../../../models/rank.model";
+import { useRank } from "../../../hooks/useRank";
+import { useAuthStore } from "../../../store/authStore";
+import { Link } from "react-router-dom";
 
 const NearRank = ({ id }: Rank) => {
   const { nearRank } = useRank();
   const { isLoggedIn } = useAuthStore();
-  
+
   return (
     <NearRankWrapper>
       {isLoggedIn ? (
@@ -21,10 +22,7 @@ const NearRank = ({ id }: Rank) => {
             </thead>
             <tbody>
               {nearRank?.nearRankers.map((data, idx) => (
-                <tr
-                  key={idx} 
-                  className={data.id === id ? "highlight" : ''}
-                >
+                <tr key={idx} className={data.id === id ? "highlight" : ""}>
                   <td>{data.rank}</td>
                   <td>{data.id}</td>
                   <td>{data.score}점</td>
@@ -35,11 +33,12 @@ const NearRank = ({ id }: Rank) => {
         </NearRankLogin>
       ) : (
         <NearRankLogout>
-          로그인 후 이용 가능합니다.
+          <div>로그인 후 이용 가능합니다.</div>
+          <Link to="/login">로그인 하러 가기</Link>
         </NearRankLogout>
       )}
     </NearRankWrapper>
-  )
+  );
 };
 
 const NearRankWrapper = styled.div`
@@ -58,11 +57,12 @@ const NearRankLogin = styled.div`
     border-radius: 8px;
     border-style: hidden;
 
-    th, td {
+    th,
+    td {
       border: 1px solid ${({ theme }) => theme.color.grey4};
       text-align: center;
     }
-  
+
     th {
       padding: 12px 0;
       background-color: ${({ theme }) => theme.color.primary};
@@ -70,12 +70,12 @@ const NearRankLogin = styled.div`
       font-size: ${({ theme }) => theme.text.text1};
       font-weight: 600;
     }
-  
+
     td {
       padding: 18px 0;
       font-size: ${({ theme }) => theme.text.text1};
     }
-  
+
     .highlight {
       background-color: ${({ theme }) => theme.color.grey5};
       font-weight: 600;
@@ -85,12 +85,19 @@ const NearRankLogin = styled.div`
 
 const NearRankLogout = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 8px;
   width: 100%;
   height: 242px;
   color: ${({ theme }) => theme.color.primary};
   font-size: ${({ theme }) => theme.text.text1};
+
+  a {
+    color: ${({ theme }) => theme.color.primary};
+    text-decoration: underline;
+  }
 `;
 
 export default NearRank;

--- a/src/components/common/rank/NearRank.tsx
+++ b/src/components/common/rank/NearRank.tsx
@@ -1,41 +1,54 @@
 import styled from 'styled-components';
 import { Rank } from '../../../models/rank.model';
 import { useRank } from '../../../hooks/useRank';
+import { useAuthStore } from '../../../store/authStore';
 
 const NearRank = ({ id }: Rank) => {
   const { nearRank } = useRank();
+  const { isLoggedIn } = useAuthStore();
   
   return (
     <NearRankWrapper>
-      <table>
-        <thead>
-          <tr>
-            <th>순위</th>
-            <th>이름</th>
-            <th>점수</th>
-          </tr>
-        </thead>
-        <tbody>
-          {nearRank?.nearRankers.map((data, idx) => (
-            <tr
-              key={idx} 
-              className={data.id === id ? "highlight" : ''}
-            >
-              <td>{data.rank}</td>
-              <td>{data.id}</td>
-              <td>{data.totalScore}점</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      {isLoggedIn ? (
+        <NearRankLogin>
+          <table>
+            <thead>
+              <tr>
+                <th>순위</th>
+                <th>이름</th>
+                <th>점수</th>
+              </tr>
+            </thead>
+            <tbody>
+              {nearRank?.nearRankers.map((data, idx) => (
+                <tr
+                  key={idx} 
+                  className={data.id === id ? "highlight" : ''}
+                >
+                  <td>{data.rank}</td>
+                  <td>{data.id}</td>
+                  <td>{data.score}점</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </NearRankLogin>
+      ) : (
+        <NearRankLogout>
+          로그인 후 이용 가능합니다.
+        </NearRankLogout>
+      )}
     </NearRankWrapper>
   )
 };
 
 const NearRankWrapper = styled.div`
-  border: 1px solid ${({ theme }) => theme.color.grey4};
+  border: 1px solid ${({ theme }) => theme.color.grey2};
   border-radius: 8px;
+  /* filter: blur(10px); */
+`;
 
+const NearRankLogin = styled.div`
   table {
     display: table;
     table-layout: fixed;
@@ -68,6 +81,16 @@ const NearRankWrapper = styled.div`
       font-weight: 600;
     }
   }
+`;
+
+const NearRankLogout = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 242px;
+  color: ${({ theme }) => theme.color.primary};
+  font-size: ${({ theme }) => theme.text.text1};
 `;
 
 export default NearRank;

--- a/src/components/common/rank/RankCard.tsx
+++ b/src/components/common/rank/RankCard.tsx
@@ -1,15 +1,15 @@
 import styled from 'styled-components';
 import { FaUser } from "react-icons/fa";
-import { Rank } from '../../../models/rank.model';
+import { Rank, Ranker } from '../../../models/rank.model';
 
-const RankCard = ({ id, rank, totalQuizScore }: Rank) => {
+const RankCard = ({ id, rank, score }: Ranker) => {
   return (
     <RankCardWrapper rank={rank}>
       <h1 className="rank">{rank}</h1>
       <div className="user">
         <div className="profile"><FaUser /></div>
         <div className="id">{id}</div>
-        <div className="score">{totalQuizScore}점</div>
+        <div className="score">{score}점</div>
       </div>
     </RankCardWrapper>
   )
@@ -19,7 +19,7 @@ const RankCardWrapper = styled.div<{ rank: number | undefined }>`
   padding: 16px 28px;
   padding-bottom: 40px;
   height: 100%;
-  border: 1px solid ${({ theme }) => theme.color.grey3};
+  border: 1px solid ${({ theme }) => theme.color.grey2};
   /* border: 1px solid ${({ rank, theme }) => 
     rank === 1 ? theme.color.yellow :
     rank === 2 ? theme.color.green :

--- a/src/hooks/useRank.ts
+++ b/src/hooks/useRank.ts
@@ -7,21 +7,37 @@ export const useRank = () => {
   const [topRank, setTopRank] = useState<TopRank | null>(null);
   const [nearRank, setNearRank] = useState<NearRank | null>(null);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const userRankData = await fetchRank();
-        const topRankData = await fetchTopRank();
-        const nearRankData = await fetchNearRank();
-        setUserRank(userRankData);
-        setTopRank(topRankData);
-        setNearRank(nearRankData);
-      } catch (err) {
-        console.log(err);
-      }
-    };
+  const fetchUserData = async () => {
+    try {
+      const userRankData = await fetchRank();
+      setUserRank(userRankData);
+    } catch (err) {
+      console.log(err);
+    }
+  };
 
-    fetchData();
+  const fetchTopRankData = async () => {
+    try {
+      const topRankData = await fetchTopRank();
+      setTopRank(topRankData);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const fetchNearRankData = async () => {
+    try {
+      const nearRankData = await fetchNearRank();
+      setNearRank(nearRankData);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchUserData();
+    fetchTopRankData();
+    fetchNearRankData();
   }, []);
 
   return { userRank, topRank, nearRank };

--- a/src/models/rank.model.ts
+++ b/src/models/rank.model.ts
@@ -17,5 +17,5 @@ export interface NearRank {
 export interface Ranker {
   id: string;
   rank: number;
-  totalScore: number;
+  score: number;
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import styled, { keyframes, css } from "styled-components";
 import { ReactComponent as QuizIcon } from "../assets/btnImg/quiz 1.svg";
+import { ReactComponent as InfiniteIcon } from "../assets/btnImg/infinite 1.svg";
 import { ReactComponent as RankIcon } from "../assets/btnImg/ranking 1.svg";
 import Banner from "../components/common/banner/Banner";
 import IconCard from "../components/common/IconCard";
@@ -55,6 +56,13 @@ const Home: React.FC = () => {
             Icon={QuizIcon}
             title="퀴즈 풀러 가기 🌈"
             description="#단어 #10문제 #초성힌트"
+          />
+          <IconCard
+            to="/infinite-quiz"
+            bgColor="yellow"
+            Icon={InfiniteIcon}
+            title="무한 퀴즈 챌린지 🔥"
+            description="#단어 #점수도전 #초성힌트"
           />
           <IconCard
             to="/rank"
@@ -117,7 +125,7 @@ const HomeStyle = styled.div`
   .card {
     display: flex;
     justify-content: center;
-    gap: 160px;
+    gap: 40px;
     /* padding: 10px 0; */
     @media (max-width: 1024px) {
       gap: 20px;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -68,8 +68,8 @@ const Home: React.FC = () => {
             to="/rank"
             bgColor="blue"
             Icon={RankIcon}
-            title="랭킹 확인 🥇"
-            description="#1위부터 #3위 #나의 랭크"
+            title="전체 랭킹 확인 🥇"
+            description="#전체 #나의랭킹 #점수확인"
           />
         </div>
       </StyledSection>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,6 +5,9 @@ import { ReactComponent as InfiniteIcon } from "../assets/btnImg/infinite 1.svg"
 import { ReactComponent as RankIcon } from "../assets/btnImg/ranking 1.svg";
 import Banner from "../components/common/banner/Banner";
 import IconCard from "../components/common/IconCard";
+import { useRank } from "../hooks/useRank";
+import RankCard from '../components/common/rank/RankCard';
+import NearRank from '../components/common/rank/NearRank';
 
 const messages = [
   "Welcome to the Simple Quiz! 🎉",
@@ -16,6 +19,10 @@ const messages = [
 const Home: React.FC = () => {
   const [currentMessageIndex, setCurrentMessageIndex] = useState(0);
   const [showLastMessage, setShowLastMessage] = useState(false);
+
+  const { userRank, topRank } = useRank();
+  const topRankers = topRank?.topRankers;
+  console.log(topRankers);
 
   useEffect(() => {
     if (showLastMessage) return;
@@ -49,6 +56,7 @@ const Home: React.FC = () => {
         </WelcomeMessage>
       )}
       <StyledSection className="btnSection">
+        <Title>SimpleQuiz 풀러가기</Title>
         <div className="card">
           <IconCard
             to="/quiz"
@@ -73,6 +81,22 @@ const Home: React.FC = () => {
           />
         </div>
       </StyledSection>
+      <RankSection>
+        <Title>순위 확인</Title>
+        <HighRank>
+          {topRankers && 
+            topRankers.map((data, idx) => (
+              <RankCard
+                key={idx}
+                id={data.id}
+                rank={data.rank}
+                score={data.score}
+              />
+            ))
+          }
+        </HighRank>
+        <NearRank id={userRank?.id!} />
+      </RankSection>
     </HomeStyle>
   );
 };
@@ -109,6 +133,7 @@ const HomeStyle = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
+  padding-bottom: 120px;
 
   p{
     color: ${({ theme }) => theme.color.primary};
@@ -126,7 +151,6 @@ const HomeStyle = styled.div`
     display: flex;
     justify-content: center;
     gap: 40px;
-    /* padding: 10px 0; */
     @media (max-width: 1024px) {
       gap: 20px;
     }
@@ -143,13 +167,33 @@ const HomeStyle = styled.div`
   }
 `;
 
+const Title = styled.h1`
+  margin-bottom: 24px;
+  color: ${({ theme }) => theme.color.primary};
+  font-size: ${({ theme }) => theme.heading.title3};
+  font-weight: 600;
+`;
+
 const StyledSection = styled.section`
-  padding: 20px 20px;
+  margin-bottom: 80px;
   background: ${({ theme }) => theme.color.background};
 
   .title {
     font-size: ${({ theme }) => theme.heading.title2};
   }
+`;
+
+const RankSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const HighRank = styled.section`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6%;
+  margin-bottom: 40px;
 `;
 
 export default Home;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -22,8 +22,7 @@ const Home: React.FC = () => {
 
   const { userRank, topRank } = useRank();
   const topRankers = topRank?.topRankers;
-  console.log(topRankers);
-
+  
   useEffect(() => {
     if (showLastMessage) return;
 
@@ -137,7 +136,6 @@ const HomeStyle = styled.div`
 
   p{
     color: ${({ theme }) => theme.color.primary};
-
   }
 
   .banner {

--- a/src/pages/InfiniteQuiz.tsx
+++ b/src/pages/InfiniteQuiz.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const InfiniteQuiz = () => {
+  return (
+    <InfiniteQuizWrapper>
+      <h1>InfiniteQuiz</h1>
+    </InfiniteQuizWrapper>
+  )
+};
+
+const InfiniteQuizWrapper = styled.div``;
+
+export default InfiniteQuiz;

--- a/src/pages/Rank.tsx
+++ b/src/pages/Rank.tsx
@@ -1,12 +1,10 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import RankCard from '../components/common/rank/RankCard';
-import NearRank from '../components/common/rank/NearRank';
 import { useRank } from '../hooks/useRank';
 import UnAuthorizedRank from '../components/common/rank/UnAuthorizedRank';
 
 const Rank = () => {
-  const { userRank, topRank } = useRank();
+  const { userRank } = useRank();
 
   if (!userRank) {
     return <UnAuthorizedRank />;
@@ -36,19 +34,6 @@ const Rank = () => {
             </h3>
           </div>
         </MyRank>
-        <HighRank>
-        {topRank && topRank.topRankers && 
-          topRank.topRankers.map((data, idx) => (
-            <RankCard
-              key={idx}
-              id={data.id}
-              rank={data.rank}
-              totalQuizScore={data.totalScore}
-            />
-          ))
-        }
-        </HighRank>
-        <NearRank id={userRank.id} />
       </Content>
     </RankWrapper>
   );


### PR DESCRIPTION
## 📝 작업 내용

- #45 
- 랭킹 페이지에 있는 순위 컴포넌트와 근처순위 컴포넌트를 홈 화면으로 이동하였습니다.

## ⭐️ 중점적으로 봐야 할 부분

- 랭크 모델 속성 이름 변경 (totalScore -> score)
- 연동 api 수정
<img width="535" alt="스크린샷 2024-09-08 오후 6 29 52" src="https://github.com/user-attachments/assets/88b79614-811f-4dea-a3cd-fcd11f5a3f9f">

- 근처순위 컴포넌트 로그인 여부에 따라 보이게 하기

|로그인 했을 경우|로그인 안했을 경우|
|:-:|:-:|
|<img width="929" alt="스크린샷 2024-09-08 오후 6 30 15" src="https://github.com/user-attachments/assets/832e52ee-8697-4b73-ae7a-0e322190977d">|<img width="941" alt="스크린샷 2024-09-08 오후 8 30 00" src="https://github.com/user-attachments/assets/a7d4b84d-fa9a-42a3-a285-f847faceb64c">|


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
