### PR TITLE
[#53] home성능개선

### DIFF
--- a/src/components/common/IconCard.tsx
+++ b/src/components/common/IconCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { Link } from "react-router-dom";
 import { theme } from "../../styles/theme";
 
@@ -31,7 +31,11 @@ const IconCard: React.FC<IconCardProps> = ({
   );
 };
 
-const StyledLink = styled(Link)`
+const StyledLink = styled(Link).attrs((props) => ({
+  role: "button", // role 속성 추가
+  "aria-label": `${props.title} 카드`, // aria-label 속성 추가
+}))`
+
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -56,31 +60,26 @@ const StyledLink = styled(Link)`
     max-height: 350px;
   }
 
-  @media (max-width: 480px) {
-    max-width: 200px;
-    max-height: 250px;
-  }
 `;
 
-const IconWrapper = styled.div<{ bgColor: keyof typeof theme.color }>`
+const cardCommonStyles = css`
   display: flex;
-  align-items: center;
   justify-content: center;
-  width: 100%;
-  height: 60%;
-  background-color: ${(props) => props.theme.color[props.bgColor]};
+  align-items: center;
+  text-align: center;
+  transition: transform 0.3s, box-shadow 0.3s;
+  aspect-ratio: 2 / 3;
+`;
 
+// IconCard의 고정 크기 설정 (아이콘 크기 고정)
+const IconWrapper = styled.div<{ bgColor: keyof typeof theme.color }>`
+  ${cardCommonStyles};
+  width: 100%;
+  height: 300px;
+  background-color: ${({ theme, bgColor }) => theme.color[bgColor]};
   svg {
     width: 50%;
     height: 50%;
-  }
-
-  @media (max-width: 768px) {
-    height: 60%;
-  }
-
-  @media (max-width: 480px) {
-    height: 60%;
   }
 `;
 
@@ -103,9 +102,6 @@ const CardTitle = styled.p`
     font-size: ${({ theme }) => theme.text.text2};
   }
 
-  @media (max-width: 480px) {
-    font-size: ${({ theme }) => theme.text.text3};
-  }
 `;
 
 const CardDescription = styled.p`
@@ -115,10 +111,7 @@ const CardDescription = styled.p`
   @media (max-width: 768px) {
     font-size: ${({ theme }) => theme.text.text3};
   }
-
-  @media (max-width: 480px) {
-    font-size: ${({ theme }) => theme.text.text4};
-  }
 `;
 
-export default IconCard;
+export default React.memo(IconCard);
+// IconCard 컴포넌트는 동일한 props로 리렌더링할 필요가 없으므로 React.memo로 최적화

--- a/src/components/common/banner/Banner.tsx
+++ b/src/components/common/banner/Banner.tsx
@@ -46,13 +46,18 @@ function Banner() {
           <SwiperSlide key={index}>
             <SlideContainer>
               <ImageContainer>
-                <Image src={image} alt={`Banner ${index + 1}`} />
+              <Image 
+                  src={image} 
+                  alt={`Banner ${index + 1}`} 
+                  loading={index === 0 ? "eager" : "lazy"} 
+                  // 첫 번째 이미지는 eager, 나머지는 lazy 로딩
+                />
               </ImageContainer>
             </SlideContainer>
           </SwiperSlide>
         ))}
-        <div className="swiper-button-prev"></div>
-        <div className="swiper-button-next"></div>
+        {/* <div className="swiper-button-prev"></div>
+        <div className="swiper-button-next"></div> */}
       </Swiper>
     </BannerStyle>
   );
@@ -60,7 +65,7 @@ function Banner() {
 
 const BannerStyle = styled.div`
   padding-top: 30px;
-
+/* 
   .swiper-button-prev,
   .swiper-button-next {
     color: #706f6f !important;
@@ -72,7 +77,7 @@ const BannerStyle = styled.div`
     justify-content: center !important;
     align-items: center !important;
     margin: -1% 8% !important;
-  }
+  } */
 
 `;
 
@@ -94,9 +99,10 @@ const ImageContainer = styled.div`
 
 const Image = styled.img`
   width: 100%;
-  height: 100%;
+  height: auto; 
   max-width: 1200px;
   object-fit: cover;
 `;
+
 
 export default Banner;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -34,7 +34,7 @@ const Home: React.FC = () => {
         }
         return (prevIndex + 1) % messages.length;
       });
-    }, 3000); // 메시지가 3초마다 변경됩니다
+    }, 3000); 
 
     return () => clearInterval(timer);
   }, [showLastMessage]);
@@ -91,8 +91,7 @@ const Home: React.FC = () => {
                 rank={data.rank}
                 score={data.score}
               />
-            ))
-          }
+            ))}
         </HighRank>
         <NearRank id={userRank?.id!} />
       </RankSection>
@@ -121,10 +120,12 @@ const WelcomeMessage = styled.div<{ lastMessage: boolean }>`
   animation: ${({ lastMessage }) =>
     lastMessage
       ? css`
-          ${fadeIn} 2s ease-in-out
+          ${fadeIn} 2s ease-in-out;
+          will-change: opacity;
         `
       : css`
-          ${fadeInOut} 3s ease-in-out
+          ${fadeInOut} 3s ease-in-out;
+          will-change: opacity;
         `};
 `;
 
@@ -134,7 +135,7 @@ const HomeStyle = styled.div`
   gap: 20px;
   padding-bottom: 120px;
 
-  p{
+  p {
     color: ${({ theme }) => theme.color.primary};
   }
 


### PR DESCRIPTION
## 📝 작업 내용

- 홈페이지의 성능 점수를 향상 시켰습니다. 

## ⭐️ 중점적으로 봐야 할 부분
![image (1)](https://github.com/user-attachments/assets/407212b0-bd62-4f7a-9623-65a7743d4cde)
- 72점으로 낮은 performance 점수 향상을 위해서 리펙토링을 진행 하였습니다.

- 홈
  - will-change: opacity 속성을 사용해 브라우저가 애니메이션 효과를 미리 준비하도록 하여 렌더링 성능을 최적화했습니다.
 
- IconCard
  - React.memo를 사용하여 동일한 props가 전달되었을 때 불필요한 리렌더링을 방지했습니다. 
  - 아이콘과 텍스트를 담는 IconWrapper에 고정된 높이와 비율을 설정하여 레이아웃 이동을 막고 CLS를 방지했습니다.
  - role="button"과 aria-label 속성을 추가하여 접근성을 개선했습니다. 이를 통해 보조 도구(스크린 리더)에서의 접근성을 개선하고자 하였습니다.
  - css mixin을 사용해 공통 스타일을 추출하여 코드 중복을 줄였습니다. 
 
- Banenr
  - Lazy Loading 최적화: 배너의 첫 번째 이미지는 loading="eager"로 즉시 로드되며, 나머지 이미지는 loading="lazy"로 처리해, 이미지 로드를 지연시켜 LCP를 개선하여 성능을 최적화했습니다.
 
![image (2)](https://github.com/user-attachments/assets/6f8d188f-c03e-4d2b-a5d2-5f95133ecf9c)

## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
